### PR TITLE
fix: Additional check in leaveChatRoom.

### DIFF
--- a/browser/react/components/Beth.js
+++ b/browser/react/components/Beth.js
@@ -9,7 +9,7 @@ export default class Beth extends React.Component {
   }
 
   componentWillUnmount () {
-    leaveChatRoom('beth');
+    leaveChatRoom();
   }
   render () {
     return (

--- a/browser/react/components/Joey.js
+++ b/browser/react/components/Joey.js
@@ -9,7 +9,7 @@ export default class Joey extends React.Component {
   }
 
   componentWillUnmount () {
-    leaveChatRoom('joey');
+    leaveChatRoom();
   }
   render () {
     return (

--- a/browser/react/components/Lobby.js
+++ b/browser/react/components/Lobby.js
@@ -9,7 +9,7 @@ export default class Lobby extends React.Component {
   }
 
   componentWillUnmount () {
-    leaveChatRoom('lobby');
+    leaveChatRoom();
   }
   render () {
     return (

--- a/browser/react/components/Sean.js
+++ b/browser/react/components/Sean.js
@@ -9,7 +9,7 @@ export default class Sean extends React.Component {
   }
 
   componentWillUnmount () {
-    leaveChatRoom('sean');
+    leaveChatRoom();
   }
 
   render () {

--- a/browser/react/components/Yoonah.js
+++ b/browser/react/components/Yoonah.js
@@ -9,7 +9,7 @@ export default class Yoonah extends React.Component {
   }
 
   componentWillUnmount () {
-    leaveChatRoom('yoonah');
+    leaveChatRoom();
   }
 
   render () {

--- a/browser/webRTC/client.js
+++ b/browser/webRTC/client.js
@@ -53,8 +53,8 @@ export function joinChatRoom (room, errorback) {
 // Called by a A-Frame Room's componentWillUnmount lifecycle hook, it leaveChatRoom
 //   triggers server-side logic to leave the matching socket.io room and tear down
 //   existing WebRTC connections.
-export function leaveChatRoom (room) {
-  signalingSocket.emit('leaveChatRoom', room);
+export function leaveChatRoom () {
+  signalingSocket.emit('leaveChatRoom');
 }
 
 // accepts conifg

--- a/server/socket.js
+++ b/server/socket.js
@@ -52,7 +52,7 @@ module.exports = io => {
     socket.on('disconnect', () => {
       store.dispatch(removeUserAndEmit(socket));
       console.log(chalk.magenta(`${socket.id} has disconnected`));
-      leaveChatRoom(socket.currentChatRoom);
+      leaveChatRoom();
       console.log(`[${socket.id}] disconnected`);
       delete sockets[socket.id];
     });
@@ -89,7 +89,7 @@ module.exports = io => {
         console.log('Not currently in room, so nothing to leave');
       }
     }
-    socket.on('leaveChatRoom', (room) => leaveChatRoom(room));
+    socket.on('leaveChatRoom', () => leaveChatRoom());
 
     // If any user is an Ice Candidate, tells other users to set up a ICE connection with them
     socket.on('relayICECandidate', function (config) {

--- a/server/socket.js
+++ b/server/socket.js
@@ -52,9 +52,7 @@ module.exports = io => {
     socket.on('disconnect', () => {
       store.dispatch(removeUserAndEmit(socket));
       console.log(chalk.magenta(`${socket.id} has disconnected`));
-      if (socket.currentChatRoom) {
-        leaveChatRoom(socket.currentChatRoom);
-      }
+      leaveChatRoom(socket.currentChatRoom);
       console.log(`[${socket.id}] disconnected`);
       delete sockets[socket.id];
     });
@@ -79,12 +77,16 @@ module.exports = io => {
     //   connections with the person leaving the room.
     function leaveChatRoom () {
       const room = socket.currentChatRoom;
-      console.log(`[${socket.id}] leaveChatRoom ${room}`);
-      socket.leave(room);
-      delete rooms[room][socket.id];
-      for (const id in rooms[room]) {
-        rooms[room][id].emit('removePeer', { 'peer_id': socket.id });
-        socket.emit('removePeer', { 'peer_id': id });
+      if (room) {
+        console.log(`[${socket.id}] leaveChatRoom ${room}`);
+        socket.leave(room);
+        delete rooms[room][socket.id];
+        for (const id in rooms[room]) {
+          rooms[room][id].emit('removePeer', { 'peer_id': socket.id });
+          socket.emit('removePeer', { 'peer_id': id });
+        }
+      } else {
+        console.log('Not currently in room, so nothing to leave');
       }
     }
     socket.on('leaveChatRoom', (room) => leaveChatRoom(room));


### PR DESCRIPTION
There was a bug where if a user disallowed sharing their microphone, when the user tried to navigate between scenes, leaveChatRoom() would fire in componentWillUnmount with socket.currentChatRoom not set to anything, and the whole app would crash. I recreated the bug, crashed the server, created the fix, recreated the bug, and the server stopped crashing, so I think we're good. (crosses fingers....)

I created a safety check before for this, but it was in the socket.on disconnect logic, which is insufficient now that we render rooms without a full page refresh so headsets can work.