### PR TITLE
Force ssl

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -22,7 +22,7 @@ const forceSSL = function (req, res, next) {
 };
 
 if (process.env.NODE_ENV === 'production') {
-  c
+  console.log('prod land man');
   app.use(forceSSL);
 }
 

--- a/server/index.js
+++ b/server/index.js
@@ -8,6 +8,22 @@ const { resolve } = require('path');
 const chalk = require('chalk');
 const passport = require('passport');
 
+// Custom Middleware to redirect HTTP to https using request headers appended
+// By one of Heroku's AWS ELB instances.
+// http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/x-forwarded-headers.html
+// Note that this is technically vulnerable to man-in-the-middle attacks
+const forceSSL = function (req, res, next) {
+  if (req.headers['x-forwarded-proto'] !== 'https') {
+    console.log('forcing SSL');
+    return res.redirect(['https://', req.get('Host'), req.url].join(''));
+  }
+  return next();
+};
+
+if (process.env.NODE_ENV === 'production') {
+  app.use(forceSSL);
+}
+
 if (process.env.NODE_ENV !== 'production') {
   // Logging middleware (dev only)
   const morgan = require('morgan');

--- a/server/index.js
+++ b/server/index.js
@@ -15,14 +15,16 @@ const passport = require('passport');
 const forceSSL = function (req, res, next) {
   console.log(JSON.stringify(req.headers));
   if (req.headers['x-forwarded-proto'] !== 'https') {
-    console.log('forcing SSL');
-    return res.redirect(['https://', req.get('Host'), req.url].join(''));
+    const clientIP = req.headers['x-forwarded-for'];
+    const redirectTarget = ['https://', req.get('Host'), req.url].join('');
+    console.log(chalk.blue(`Redirecting ${clientIP} to ${redirectTarget}`));
+    return res.redirect(redirectTarget);
   }
   return next();
 };
 
 if (process.env.NODE_ENV === 'production') {
-  console.log('prod land man');
+  console.log(chalk.blue('Production Environment detected, so redirect to HTTPS'));
   app.use(forceSSL);
 }
 

--- a/server/index.js
+++ b/server/index.js
@@ -22,6 +22,7 @@ const forceSSL = function (req, res, next) {
 };
 
 if (process.env.NODE_ENV === 'production') {
+  c
   app.use(forceSSL);
 }
 

--- a/server/index.js
+++ b/server/index.js
@@ -13,7 +13,6 @@ const passport = require('passport');
 // http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/x-forwarded-headers.html
 // Note that this is technically vulnerable to man-in-the-middle attacks
 const forceSSL = function (req, res, next) {
-  console.log(JSON.stringify(req.headers));
   if (req.headers['x-forwarded-proto'] !== 'https') {
     const clientIP = req.headers['x-forwarded-for'];
     const redirectTarget = ['https://', req.get('Host'), req.url].join('');

--- a/server/index.js
+++ b/server/index.js
@@ -13,6 +13,7 @@ const passport = require('passport');
 // http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/x-forwarded-headers.html
 // Note that this is technically vulnerable to man-in-the-middle attacks
 const forceSSL = function (req, res, next) {
+  console.log(JSON.stringify(req.headers));
   if (req.headers['x-forwarded-proto'] !== 'https') {
     console.log('forcing SSL');
     return res.redirect(['https://', req.get('Host'), req.url].join(''));


### PR DESCRIPTION
When in production, redirect all HTTP traffic to the HTTP equivalent to be sure that they can establish a WebRTC connection. You can test this on [http://secure-transcend.herokuapp.com](http://secure-transcend.herokuapp.com). Resolves #73 